### PR TITLE
Set Whoa's entry point to WinMain on Windows builds

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(WHOA_SYSTEM_WIN)
     file(GLOB PRIVATE_SOURCES "win/*.cpp")
 
-    add_executable(Whoa ${PRIVATE_SOURCES})
+    add_executable(Whoa WIN32 ${PRIVATE_SOURCES})
 
     target_link_libraries(Whoa
         PRIVATE

--- a/src/app/win/Whoa.cpp
+++ b/src/app/win/Whoa.cpp
@@ -1,6 +1,6 @@
 #include "client/Client.hpp"
 
-int main(int argc, char* argv[]) {
+int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
     // TODO
 
     CommonMain();

--- a/src/app/win/Whoa.cpp
+++ b/src/app/win/Whoa.cpp
@@ -1,4 +1,5 @@
 #include "client/Client.hpp"
+#include <windows.h>
 
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
     // TODO


### PR DESCRIPTION
Changes the application's subsystem from console to window, see [/SUBSYSTEM (MSDN)](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170) for details.