### PR TITLE
feat(net): handle incoming data in Grunt::ClientLink

### DIFF
--- a/src/net/grunt/ClientLink.hpp
+++ b/src/net/grunt/ClientLink.hpp
@@ -7,14 +7,24 @@
 #include "net/grunt/Timer.hpp"
 #include "net/srp/SRP6_Client.hpp"
 #include "net/Types.hpp"
+#include <common/DataStore.hpp>
 #include <storm/Thread.hpp>
 
-class CDataStore;
 class WowConnection;
 
 class Grunt::ClientLink : public WowConnectionResponse, Grunt::Pending, Grunt::Timer::Event {
     public:
         // Types
+        enum COMMAND {
+            CMD_AUTH_LOGON_CHALLENGE        = 0,
+            CMD_AUTH_LOGON_PROOF            = 1,
+            CMD_AUTH_RECONNECT_CHALLENGE    = 2,
+            CMD_AUTH_RECONNECT_PROOF        = 3,
+            CMD_REALM_LIST                  = 16,
+            CMD_XFER_INITIATE               = 48,
+            CMD_XFER_DATA                   = 49,
+        };
+
         struct Logon {
             const char* accountName;
             const char* password;
@@ -34,6 +44,7 @@ class Grunt::ClientLink : public WowConnectionResponse, Grunt::Pending, Grunt::T
         int32_t m_state;
         SRP6_Client m_srpClient;
         SCritSect m_critSect;
+        CDataStore m_datastore1B0;
         WowConnection* m_connection = nullptr;
         ClientResponse* m_clientResponse;
         char m_accountName[1280];
@@ -41,10 +52,18 @@ class Grunt::ClientLink : public WowConnectionResponse, Grunt::Pending, Grunt::T
         // Virtual member functions
         virtual void WCConnected(WowConnection* conn, WowConnection* inbound, uint32_t timeStamp, const NETCONNADDR* addr);
         virtual void WCCantConnect(WowConnection* conn, uint32_t timeStamp, NETCONNADDR* addr);
+        virtual void WCDataReady(WowConnection* conn, uint32_t timeStamp, uint8_t* data, int32_t len);
         virtual void Call();
 
         // Member functions
         ClientLink(Grunt::ClientResponse& clientResponse);
+        int32_t CmdAuthLogonChallenge(CDataStore& msg);
+        int32_t CmdAuthLogonProof(CDataStore& msg);
+        int32_t CmdAuthReconnectChallenge(CDataStore& msg);
+        int32_t CmdAuthReconnectProof(CDataStore& msg);
+        int32_t CmdRealmList(CDataStore& msg);
+        int32_t CmdXferData(CDataStore& msg);
+        int32_t CmdXferInitiate(CDataStore& msg);
         void Connect(const char* a2);
         void Disconnect();
         void LogonNewSession(const Logon& logon);

--- a/src/net/grunt/Command.hpp
+++ b/src/net/grunt/Command.hpp
@@ -1,0 +1,45 @@
+#ifndef NET_GRUNT_COMMAND_HPP
+#define NET_GRUNT_COMMAND_HPP
+
+#include "net/Grunt.hpp"
+
+template <class T>
+class Grunt::Command {
+    public:
+    // Static members
+    static int32_t Process(CDataStore& msg, Command<T>* commands, uint32_t commandCount, T& a4, uint32_t& pos);
+
+    // Member variables
+    int32_t cmd;
+    const char* name;
+    int32_t (T::*callback)(CDataStore& msg);
+    uint32_t unk;
+};
+
+template <class T>
+int32_t Grunt::Command<T>::Process(CDataStore& msg, Command<T>* commands, uint32_t commandCount, T& a4, uint32_t& pos) {
+    uint8_t cmd;
+    msg.Get(cmd);
+
+    for (uint32_t i = 0; i < commandCount; i++) {
+        auto& command = commands[i];
+
+        if (command.cmd == cmd) {
+            auto callback = command.callback;
+            auto result = (a4.*callback)(msg);
+
+            if (result == 0) {
+                return 1;
+            } else {
+                // TODO
+                return 0;
+            }
+        }
+    }
+
+    // TODO
+
+    return 0;
+}
+
+#endif

--- a/src/net/grunt/Grunt.hpp
+++ b/src/net/grunt/Grunt.hpp
@@ -4,8 +4,12 @@
 namespace Grunt {
     class ClientLink;
     class ClientResponse;
+    template <class>
+    class Command;
     class Pending;
     class Timer;
+
+    extern Command<ClientLink> s_clientCommands[];
 }
 
 #endif


### PR DESCRIPTION
This PR implements `Grunt::ClientLink::WCDataReady`, adds `Grunt::Command`, and sets up command entries and callback function stubs for the 7 Grunt client commands used in 3.3.5a.