### PR TITLE
feat(net): handle get version proof

### DIFF
--- a/src/net/grunt/ClientResponse.hpp
+++ b/src/net/grunt/ClientResponse.hpp
@@ -11,11 +11,12 @@ class Grunt::ClientResponse {
         virtual bool Connected(const NETADDR& addr) = 0;
         virtual bool OnlineIdle() = 0;
         virtual void GetLogonMethod() = 0;
-        virtual void GetVersionProof(const uint8_t* a2) = 0;
+        virtual void GetVersionProof(const uint8_t* crcSalt) = 0;
         virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4) = 0;
         virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) = 0;
         virtual void SetTokenInfo(bool enabled, uint8_t required) = 0;
         virtual void LogonResult(Result result, const uint8_t* a3, uint32_t a4, uint16_t a5) = 0;
+        virtual LOGIN_STATE NextSecurityState(LOGIN_STATE state) = 0;
         virtual void GetRealmList() = 0;
         virtual void Logon(const char* a2, const char* a3) = 0;
         virtual void Logoff() = 0;

--- a/src/net/login/GruntLogin.cpp
+++ b/src/net/login/GruntLogin.cpp
@@ -88,8 +88,14 @@ void GruntLogin::GetRealmList() {
     // TODO
 }
 
-void GruntLogin::GetVersionProof(const uint8_t* a2) {
-    // TODO
+void GruntLogin::GetVersionProof(const uint8_t* crcSalt) {
+    if (this->IsReconnect()) {
+        // TODO
+    } else {
+        memcpy(this->m_crcSalt, crcSalt, sizeof(this->m_crcSalt));
+        LOGIN_STATE nextState = this->NextSecurityState(LOGIN_STATE_FIRST_SECURITY);
+        this->m_loginResponse->UpdateLoginStatus(nextState, LOGIN_OK, nullptr, 0);
+    }
 }
 
 void GruntLogin::Init(LoginResponse* loginResponse) {
@@ -131,6 +137,11 @@ void GruntLogin::Logon(const char* a2, const char* a3) {
 
 void GruntLogin::LogonResult(Grunt::Result result, const uint8_t* a3, uint32_t a4, uint16_t a5) {
     // TODO
+}
+
+LOGIN_STATE GruntLogin::NextSecurityState(LOGIN_STATE state) {
+    // TODO
+    return LOGIN_STATE_CHECKINGVERSIONS;
 }
 
 void GruntLogin::SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) {

--- a/src/net/login/GruntLogin.hpp
+++ b/src/net/login/GruntLogin.hpp
@@ -8,17 +8,19 @@
 class GruntLogin : public Login {
     public:
         // Member variables
+        uint8_t m_crcSalt[16];
         Grunt::ClientLink* m_clientLink = nullptr;
 
         // Virtual member functions
         virtual ~GruntLogin();
         virtual bool Connected(const NETADDR& addr);
         virtual void GetLogonMethod();
-        virtual void GetVersionProof(const uint8_t* a2);
+        virtual void GetVersionProof(const uint8_t* crcSalt);
         virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4);
         virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11);
         virtual void SetTokenInfo(bool enabled, uint8_t tokenRequired);
         virtual void LogonResult(Grunt::Result result, const uint8_t* a3, uint32_t a4, uint16_t a5);
+        virtual LOGIN_STATE NextSecurityState(LOGIN_STATE state);
         virtual void GetRealmList();
         virtual void Logon(const char* a2, const char* a3);
         virtual void Logoff();

--- a/src/net/login/LoginResponse.cpp
+++ b/src/net/login/LoginResponse.cpp
@@ -1,0 +1,12 @@
+#include "net/login/LoginResponse.hpp"
+
+void LoginResponse::UpdateLoginStatus(LOGIN_STATE state, LOGIN_RESULT result, const char* a4, uint16_t a5) {
+    this->m_loginState = state;
+    this->m_loginResult = result;
+
+    // TODO string lookups
+    const char* stateStr = nullptr;
+    const char* resultStr = nullptr;
+
+    this->LoginServerStatus(state, result, a4, stateStr, resultStr, a5);
+}

--- a/src/net/login/LoginResponse.hpp
+++ b/src/net/login/LoginResponse.hpp
@@ -11,6 +11,9 @@ class LoginResponse {
 
         // Virtual member functions
         virtual void LoginServerStatus(LOGIN_STATE state, LOGIN_RESULT result, const char* addrStr, const char* stateStr, const char* resultStr, uint16_t a7) = 0;
+
+        // Member functions
+        void UpdateLoginStatus(LOGIN_STATE state, LOGIN_RESULT result, const char* a4, uint16_t a5);
 };
 
 #endif


### PR DESCRIPTION
This PR wires up the logic needed to kick Grunt login state to `LOGIN_STATE_CHECKINGVERSIONS`.