### PR TITLE
feat(net): hook up prove version for grunt logins

### DIFF
--- a/src/net/grunt/ClientLink.hpp
+++ b/src/net/grunt/ClientLink.hpp
@@ -69,6 +69,7 @@ class Grunt::ClientLink : public WowConnectionResponse, Grunt::Pending, Grunt::T
         void Disconnect();
         void LogonNewSession(const Logon& logon);
         void PackLogon(CDataStore& msg, const Logon& logon);
+        void ProveVersion(const uint8_t* versionChecksum);
         void Send(CDataStore& msg);
         void SetState(int32_t state);
 };

--- a/src/net/grunt/ClientResponse.hpp
+++ b/src/net/grunt/ClientResponse.hpp
@@ -11,7 +11,7 @@ class Grunt::ClientResponse {
         virtual bool Connected(const NETADDR& addr) = 0;
         virtual bool OnlineIdle() = 0;
         virtual void GetLogonMethod() = 0;
-        virtual void GetVersionProof(const uint8_t* crcSalt) = 0;
+        virtual void GetVersionProof(const uint8_t* versionChallenge) = 0;
         virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4) = 0;
         virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) = 0;
         virtual void SetTokenInfo(bool enabled, uint8_t required) = 0;
@@ -19,6 +19,7 @@ class Grunt::ClientResponse {
         virtual LOGIN_STATE NextSecurityState(LOGIN_STATE state) = 0;
         virtual void GetRealmList() = 0;
         virtual void Logon(const char* a2, const char* a3) = 0;
+        virtual void ProveVersion(const uint8_t* versionChecksum) = 0;
         virtual void Logoff() = 0;
         virtual void Init(LoginResponse* loginResponse) = 0;
 };

--- a/src/net/login/GruntLogin.cpp
+++ b/src/net/login/GruntLogin.cpp
@@ -88,11 +88,11 @@ void GruntLogin::GetRealmList() {
     // TODO
 }
 
-void GruntLogin::GetVersionProof(const uint8_t* crcSalt) {
+void GruntLogin::GetVersionProof(const uint8_t* versionChallenge) {
     if (this->IsReconnect()) {
         // TODO
     } else {
-        memcpy(this->m_crcSalt, crcSalt, sizeof(this->m_crcSalt));
+        memcpy(this->m_versionChallenge, versionChallenge, sizeof(this->m_versionChallenge));
         LOGIN_STATE nextState = this->NextSecurityState(LOGIN_STATE_FIRST_SECURITY);
         this->m_loginResponse->UpdateLoginStatus(nextState, LOGIN_OK, nullptr, 0);
     }
@@ -142,6 +142,32 @@ void GruntLogin::LogonResult(Grunt::Result result, const uint8_t* a3, uint32_t a
 LOGIN_STATE GruntLogin::NextSecurityState(LOGIN_STATE state) {
     // TODO
     return LOGIN_STATE_CHECKINGVERSIONS;
+}
+
+void GruntLogin::ProveVersion(const uint8_t* versionChecksum) {
+    if (!this->m_loggedOn) {
+        return;
+    }
+
+    this->m_clientLink->ProveVersion(versionChecksum);
+
+    this->m_loginResponse->m_loginState = LOGIN_STATE_HANDSHAKING;
+    this->m_loginResponse->m_loginResult = LOGIN_OK;
+
+    char stateStr[64];
+    SStrCopy(stateStr, Grunt::g_LoginStateStringNames[LOGIN_STATE_HANDSHAKING], sizeof(stateStr));
+
+    char resultStr[64];
+    SStrCopy(resultStr, Grunt::g_LoginResultStringNames[LOGIN_OK], sizeof(resultStr));
+
+    this->m_loginResponse->LoginServerStatus(
+        LOGIN_STATE_HANDSHAKING,
+        LOGIN_OK,
+        nullptr,
+        stateStr,
+        resultStr,
+        0
+    );
 }
 
 void GruntLogin::SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) {

--- a/src/net/login/GruntLogin.hpp
+++ b/src/net/login/GruntLogin.hpp
@@ -8,14 +8,14 @@
 class GruntLogin : public Login {
     public:
         // Member variables
-        uint8_t m_crcSalt[16];
+        uint8_t m_versionChallenge[16];
         Grunt::ClientLink* m_clientLink = nullptr;
 
         // Virtual member functions
         virtual ~GruntLogin();
         virtual bool Connected(const NETADDR& addr);
         virtual void GetLogonMethod();
-        virtual void GetVersionProof(const uint8_t* crcSalt);
+        virtual void GetVersionProof(const uint8_t* versionChallenge);
         virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4);
         virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11);
         virtual void SetTokenInfo(bool enabled, uint8_t tokenRequired);
@@ -23,6 +23,7 @@ class GruntLogin : public Login {
         virtual LOGIN_STATE NextSecurityState(LOGIN_STATE state);
         virtual void GetRealmList();
         virtual void Logon(const char* a2, const char* a3);
+        virtual void ProveVersion(const uint8_t* versionChecksum);
         virtual void Logoff();
         virtual void Init(LoginResponse* loginResponse);
 };

--- a/src/net/srp/SRP6_Client.hpp
+++ b/src/net/srp/SRP6_Client.hpp
@@ -8,6 +8,8 @@ class SRP6_Random;
 class SRP6_Client {
     public:
     // Member variables
+    uint8_t clientPublicKey[32];
+    uint8_t clientProof[20];
     uint8_t accountNameDigest[SHA1_DIGEST_SIZE];
     uint8_t interimDigest[SHA1_DIGEST_SIZE];
     SHA1_CONTEXT ctx;


### PR DESCRIPTION
Values used in the sent packet will be empty or misleading until we land a big int implementation and fill in `SRP6_Client::CalculateProof`.