### PR TITLE
feat(net): clean up and implement more of CmdAuthLogonChallenge

### DIFF
--- a/src/net/grunt/ClientResponse.hpp
+++ b/src/net/grunt/ClientResponse.hpp
@@ -13,8 +13,8 @@ class Grunt::ClientResponse {
         virtual bool OnlineIdle() = 0;
         virtual void GetLogonMethod() = 0;
         virtual void GetVersionProof(const uint8_t* versionChallenge) = 0;
-        virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4) = 0;
-        virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) = 0;
+        virtual void SetPinInfo(bool enabled, uint32_t gridSeed, const uint8_t* salt) = 0;
+        virtual void SetMatrixInfo(bool enabled, uint8_t width, uint8_t height, uint8_t a5, uint8_t a6, bool a7, uint8_t challengeCount, uint64_t seed, const uint8_t* sessionKey, uint32_t a11) = 0;
         virtual void SetTokenInfo(bool enabled, uint8_t required) = 0;
         virtual void LogonResult(Result result, const uint8_t* sessionKey, uint32_t sessionKeyLen, uint16_t flags) = 0;
         virtual void RealmListResult(CDataStore* msg) = 0;

--- a/src/net/login/GruntLogin.cpp
+++ b/src/net/login/GruntLogin.cpp
@@ -282,14 +282,14 @@ void GruntLogin::ProveVersion(const uint8_t* versionChecksum) {
     );
 }
 
-void GruntLogin::SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11) {
+void GruntLogin::SetMatrixInfo(bool enabled, uint8_t width, uint8_t height, uint8_t a5, uint8_t a6, bool a7, uint8_t challengeCount, uint64_t seed, const uint8_t* sessionKey, uint32_t a11) {
     // TODO
 }
 
-void GruntLogin::SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4) {
+void GruntLogin::SetPinInfo(bool enabled, uint32_t gridSeed, const uint8_t* salt) {
     // TODO
 }
 
-void GruntLogin::SetTokenInfo(bool enabled, uint8_t tokenRequired) {
+void GruntLogin::SetTokenInfo(bool enabled, uint8_t required) {
     // TODO
 }

--- a/src/net/login/GruntLogin.hpp
+++ b/src/net/login/GruntLogin.hpp
@@ -16,9 +16,9 @@ class GruntLogin : public Login {
         virtual bool Connected(const NETADDR& addr);
         virtual void GetLogonMethod();
         virtual void GetVersionProof(const uint8_t* versionChallenge);
-        virtual void SetPinInfo(bool enabled, uint32_t a3, const uint8_t* a4);
-        virtual void SetMatrixInfo(bool enabled, uint8_t a3, uint8_t a4, uint8_t a5, uint8_t a6, bool a7, uint8_t a8, uint64_t a9, const uint8_t* a10, uint32_t a11);
-        virtual void SetTokenInfo(bool enabled, uint8_t tokenRequired);
+        virtual void SetPinInfo(bool enabled, uint32_t gridSeed, const uint8_t* salt);
+        virtual void SetMatrixInfo(bool enabled, uint8_t width, uint8_t height, uint8_t a5, uint8_t a6, bool a7, uint8_t challengeCount, uint64_t seed, const uint8_t* sessionKey, uint32_t a11);
+        virtual void SetTokenInfo(bool enabled, uint8_t required);
         virtual void LogonResult(Grunt::Result result, const uint8_t* sessionKey, uint32_t sessionKeyLen, uint16_t flags);
         virtual LOGIN_STATE NextSecurityState(LOGIN_STATE state);
         virtual int32_t GetServerId();


### PR DESCRIPTION
This PR:
- Replaces presumably inlined versions of `CDataStore::IsValid` with calls to `CDataStore::IsValid`
- Eliminates magic numbers from `CanRead` calls
- Enables more of the matrix authentication path
- Adds missing argument names to auth related functions